### PR TITLE
Fixes (WIP)

### DIFF
--- a/Source/Coop/Player/FirearmControllerPatches/FirearmController_GetMalfunctionState.cs
+++ b/Source/Coop/Player/FirearmControllerPatches/FirearmController_GetMalfunctionState.cs
@@ -1,0 +1,58 @@
+﻿using EFT.InventoryLogic;
+using StayInTarkov.Coop.Players;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StayInTarkov.Coop.Player.FirearmControllerPatches
+{
+    public class FirearmController_GetMalfunctionState : ModuleReplicationPatch
+    {
+        public override Type InstanceType => typeof(EFT.Player.FirearmController);
+        public override string MethodName => "GetMalfunctionState";
+
+        protected override MethodBase GetTargetMethod()
+        {
+            return ReflectionHelpers.GetMethodForType(InstanceType, MethodName);
+        }
+
+        [PatchPrefix]
+        public static bool Prefix(ref Weapon.EMalfunctionState __result, EFT.Player.FirearmController __instance, EFT.Player ____player)
+        {
+            var botPlayer = ____player as CoopBot;
+            if (botPlayer != null)
+            {
+                __result = botPlayer.MalfunctionState;
+                return false;
+            }
+
+            var player = ____player as CoopPlayer;
+            if (player == null || player.IsYourPlayer)
+                return true;
+
+            __result = player.MalfunctionState;
+            return false;
+            
+        }
+
+        [PatchPostfix]
+        public static void Postfix(ref Weapon.EMalfunctionState __result, EFT.Player.FirearmController __instance, EFT.Player ____player)
+        {
+            var player = ____player as CoopPlayer;
+            if (player == null || !player.IsYourPlayer)
+                return;
+
+            player.WeaponPacket.HasMalfunctionState = true;
+            player.WeaponPacket.MalfunctionState = __result;
+            player.WeaponPacket.ToggleSend();
+        }
+
+        public override void Replicated(EFT.Player player, Dictionary<string, object> dict)
+        {
+
+        }
+    }
+}

--- a/Source/Coop/Player/FirearmControllerPatches/FirearmController_SetTriggerPressed_Patch.cs
+++ b/Source/Coop/Player/FirearmControllerPatches/FirearmController_SetTriggerPressed_Patch.cs
@@ -16,17 +16,21 @@ namespace StayInTarkov.Coop.Player.FirearmControllerPatches
         }
 
         [PatchPostfix]
-        public static void PostPatch(EFT.Player.FirearmController __instance, bool pressed, EFT.Player ____player)
+        public static void Postfix(EFT.Player.FirearmController __instance, bool pressed, EFT.Player ____player)
         {
 
             var botPlayer = ____player as CoopBot;
             if (botPlayer != null)
             {
+                /*
                 if (__instance.Weapon.MalfState.State != EFT.InventoryLogic.Weapon.EMalfunctionState.None)
                 {
                     botPlayer.WeaponPacket.HasMalfunction = true;
                     botPlayer.WeaponPacket.MalfunctionState = __instance.Weapon.MalfState.State;
                 }
+                */
+
+                botPlayer.WeaponPacket.HasIsTriggerPressedPacket = true;
                 botPlayer.WeaponPacket.IsTriggerPressed = pressed;
                 botPlayer.WeaponPacket.ToggleSend();
                 return;
@@ -36,11 +40,15 @@ namespace StayInTarkov.Coop.Player.FirearmControllerPatches
             if (player == null || !player.IsYourPlayer)
                 return;
 
+            /*
             if (__instance.Weapon.MalfState.State != EFT.InventoryLogic.Weapon.EMalfunctionState.None)
             {
                 player.WeaponPacket.HasMalfunction = true;
                 player.WeaponPacket.MalfunctionState = __instance.Weapon.MalfState.State;
             }
+            */
+
+            player.WeaponPacket.HasIsTriggerPressedPacket = true;
             player.WeaponPacket.IsTriggerPressed = pressed;
             player.WeaponPacket.ToggleSend();
         }

--- a/Source/Coop/Players/CoopPlayer.cs
+++ b/Source/Coop/Players/CoopPlayer.cs
@@ -39,6 +39,7 @@ namespace StayInTarkov.Coop.Players
         public InventoryPacketQueue InventoryPackets = new(100);
         public CommonPlayerPacket CommonPlayerPacket = new("null");
         public CommonPlayerPacketQueue CommonPlayerPackets { get; set; } = new(100);
+        public Weapon.EMalfunctionState MalfunctionState { get; set; } = Weapon.EMalfunctionState.None;
 
         public static async Task<LocalPlayer> Create(
             int playerId,
@@ -992,9 +993,10 @@ namespace StayInTarkov.Coop.Players
 
             if (firearmController != null)
             {
-                if (packet.HasMalfunction)
+                if (packet.HasMalfunctionState)
                 {
-                    firearmController.Weapon.MalfState.ChangeStateSilent(packet.MalfunctionState);
+                    MalfunctionState = packet.MalfunctionState;
+                    //firearmController.Weapon.MalfState.ChangeStateSilent(packet.MalfunctionState);
                     //if (packet.MalfunctionState)
                     //{
                     //    firearmController.Weapon.MalfState.ChangeStateSilent(packet.MalfunctionState);
@@ -1023,9 +1025,8 @@ namespace StayInTarkov.Coop.Players
                     //}
                 }
 
-                firearmController.SetTriggerPressed(false);
-                if (packet.IsTriggerPressed)
-                    firearmController.SetTriggerPressed(true);
+                if (packet.HasIsTriggerPressedPacket)
+                    firearmController.SetTriggerPressed(packet.IsTriggerPressed);
 
                 if (packet.ChangeFireMode)
                     firearmController.ChangeFireMode(packet.FireMode);

--- a/Source/Networking/Packets/FirearmController/WeaponPacket.cs
+++ b/Source/Networking/Packets/FirearmController/WeaponPacket.cs
@@ -13,8 +13,9 @@ namespace StayInTarkov.Networking.Packets
     {
         public bool ShouldSend { get; private set; } = false;
         public string ProfileId { get; set; }
-        public bool HasMalfunction { get; set; }
+        public bool HasMalfunctionState { get; set; }
         public Weapon.EMalfunctionState MalfunctionState { get; set; }
+        public bool HasIsTriggerPressedPacket { get; set; }
         public bool IsTriggerPressed { get; set; }
         public bool ChangeFireMode { get; set; }
         public Weapon.EFireMode FireMode { get; set; }
@@ -54,7 +55,8 @@ namespace StayInTarkov.Networking.Packets
         public WeaponPacket(string profileId)
         {
             ProfileId = profileId;
-            HasMalfunction = false;
+            HasMalfunctionState = false;
+            HasIsTriggerPressedPacket = false;
             IsTriggerPressed = false;
             ChangeFireMode = false;
             ToggleAim = false;
@@ -83,9 +85,10 @@ namespace StayInTarkov.Networking.Packets
         public void Deserialize(NetDataReader reader)
         {
             ProfileId = reader.GetString();
-            HasMalfunction = reader.GetBool();
-            if (HasMalfunction)
+            HasMalfunctionState = reader.GetBool();
+            if (HasMalfunctionState)
                 MalfunctionState = (Weapon.EMalfunctionState)reader.GetInt();
+            HasIsTriggerPressedPacket = reader.GetBool();
             IsTriggerPressed = reader.GetBool();
             ChangeFireMode = reader.GetBool();
             FireMode = (Weapon.EFireMode)reader.GetInt();
@@ -137,9 +140,10 @@ namespace StayInTarkov.Networking.Packets
         public void Serialize(NetDataWriter writer)
         {
             writer.Put(ProfileId);
-            writer.Put(HasMalfunction);
-            if (HasMalfunction)
+            writer.Put(HasMalfunctionState);
+            if (HasMalfunctionState)
                 writer.Put((int)MalfunctionState);
+            writer.Put(HasIsTriggerPressedPacket);
             writer.Put(IsTriggerPressed);
             writer.Put(ChangeFireMode);
             writer.Put((int)FireMode);


### PR DESCRIPTION
-Fix IsTriggerPressed desync. IsTriggerPressed is called twice: when pressing (true) and when releasing (false) the trigger.

-Added better synchronization of weapon malfunction states. Fixes the player being stuck in a state where weapon actions couldn't be performed. The implementation is not the best but it's there as a PoC for a potential fix.